### PR TITLE
Don't truncate the newline character when printing out FEW_ARGS

### DIFF
--- a/calc.asm
+++ b/calc.asm
@@ -95,7 +95,7 @@ few_args:
 	mov rax, 1
 	mov rdi, 1
 	mov rsi, FEW_ARGS
-	mov rdx, 17
+	mov rdx, 18
 	syscall
 	jmp exit
 


### PR DESCRIPTION
Previously, the `few_args` routine would only print the first 17 characters of the `FEW_ARGS` constant, which resulted in the string being printed to STDOUT without a terminating newline.

This commit changes that to 18, which includes the trailing newline character (`0XA`).
