### PR TITLE
Fix readme by adding newlines in front of code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@
 ![img](https://raw.githubusercontent.com/flouthoc/calc.asm/master/art/calc.gif)
 
 <hr>
-This a simple arithmetic calculator written in x86 assembly with minimalistic operation support like `Addition` , `Subtraction` , `Multiplication` and `Division`.I have tried to kept <strong>source highly documented</strong> by commenting on each line so that beginners can easily understand the source.If you feel that these comments source or anything can be improved create a <strong>pull-request</strong> now. If you found it useful <strong> Star it </strong> or <strong>follow me on github </strong>
+
+This a simple arithmetic calculator written in x86 assembly with minimalistic operation support like `Addition`, `Subtraction` , `Multiplication` and `Division`.I have tried to kept <strong>source highly documented</strong> by commenting on each line so that beginners can easily understand the source.If you feel that these comments source or anything can be improved create a <strong>pull-request</strong> now. If you found it useful <strong> Star it </strong> or <strong>follow me on github </strong>
 
 
 <h4>Usage</h4>
+
 `./calc <operator> <operand1> <operand2>`
 
 
 <h4>Operations Supported</h4>
+
 `"+"` For Addition <br>
 `"-"` For Subtraction <br>
 `"*"` For Multiplication <br>
@@ -19,6 +22,7 @@ This a simple arithmetic calculator written in x86 assembly with minimalistic op
 
 
 <h4>Compiling</h4>
+
 ```bash
 nasm -f elf64 -o calc.o calc.asm
 ld -d calc calc.o


### PR DESCRIPTION
Add a newline in front of code blocks as otherwise Github doesn't show the code blocks properly. For example:

Before:
![image](https://user-images.githubusercontent.com/43414123/193440862-cd2e24fa-f67f-4252-a242-7a5b65530b21.png)

Now:
![image](https://user-images.githubusercontent.com/43414123/193440884-fb2ada67-7251-4350-9c94-dec157a6798a.png)
